### PR TITLE
docs(community-projects): fix stylelint playground link

### DIFF
--- a/docs/community-projects/stylelint-playground.md
+++ b/docs/community-projects/stylelint-playground.md
@@ -20,4 +20,4 @@ With Stylelint playground you can experiment with rulesets defined in different 
 
 They are actually being installed – just as they would in your project
 
-<Screenshot src="/img/community/stylelint-playground.png" alt="Stylelint Playground" href="https://chimerical-trifle-8d3c21.netlify.app/" />
+<Screenshot src="/img/community/stylelint-playground.png" alt="Stylelint Playground" href="https://stylelint.io/demo/" />


### PR DESCRIPTION
This PR will update the link to the Stylelint demo to the official one.

The URL used before is the one used via `<iframe>`. I think that may change in the future.